### PR TITLE
Replace `method.owner.service_name` with `method.receiver.class.service_name`

### DIFF
--- a/lib/grpc_opencensus_interceptor/server_interceptor.rb
+++ b/lib/grpc_opencensus_interceptor/server_interceptor.rb
@@ -71,7 +71,7 @@ module GrpcOpencensusInterceptor
     # @param [Method] method
     # @return [String]
     def get_name(method)
-      "#{method.owner.service_name}/#{camelize(method.name.to_s)}"
+      "#{method.receiver.class.service_name}/#{camelize(method.name.to_s)}"
     end
 
     # @param [Method] method


### PR DESCRIPTION
## Why

Same reason with https://github.com/wantedly/grpc_access_logging_interceptor/pull/9.

## What

Use `method.receiver.class.service_name` instead of `method.owner.service_name`.