### PR TITLE
Bump up version to v0.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    grpc_opencensus_interceptor (0.0.2)
+    grpc_opencensus_interceptor (0.0.3)
       grpc
       opencensus
 
@@ -10,11 +10,11 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    google-protobuf (3.11.4)
-    googleapis-common-protos-types (1.0.4)
-      google-protobuf (~> 3.0)
-    grpc (1.27.0)
+    google-protobuf (3.14.0)
+    googleapis-common-protos-types (1.0.5)
       google-protobuf (~> 3.11)
+    grpc (1.32.0)
+      google-protobuf (~> 3.13)
       googleapis-common-protos-types (~> 1.0)
     method_source (0.9.2)
     opencensus (0.5.0)
@@ -52,4 +52,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/grpc_opencensus_interceptor/version.rb
+++ b/lib/grpc_opencensus_interceptor/version.rb
@@ -1,3 +1,3 @@
 module GrpcOpencensusInterceptor
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
## Why

I want to apply the change https://github.com/wantedly/grpc_opencensus_interceptor/pull/7 In wantedly/servicex-ruby.

## What

Release version 0.0.3.